### PR TITLE
Remove DestroyRef from tools

### DIFF
--- a/docs/components/test-bed.md
+++ b/docs/components/test-bed.md
@@ -184,7 +184,6 @@ interface ComponentTools<T> {
   fixture: ComponentFixture<T>;
   component: T;
   injector: Injector;
-  destroyRef: DestroyRef;
   debug: DebugElement;
   query: ComponentQueryTools;
   action: ComponentActionTools;

--- a/projects/ngx-testing-tools/src/lib/components/test-bed/component-test-bed-factory.ts
+++ b/projects/ngx-testing-tools/src/lib/components/test-bed/component-test-bed-factory.ts
@@ -1,6 +1,5 @@
-import { Component, DestroyRef, EnvironmentProviders, ModuleWithProviders, Provider, Type } from '@angular/core';
+import { Component, EnvironmentProviders, ModuleWithProviders, Provider, Type } from '@angular/core';
 import { ComponentFixture, TestBed, TestBedStatic, TestModuleMetadata } from '@angular/core/testing';
-import { fromInjector } from '../../injector';
 import { MaybeArray, Nullable } from '../../models/shared.model';
 import { assertComponent } from './assert-component';
 import { assertComponentFixture } from './assert-fixture';
@@ -19,7 +18,6 @@ export class ComponentTestBedFactory<ComponentType> {
 
   private testBed: TestBedStatic = TestBed;
   private fixture: ComponentFixture<ComponentType> = null!;
-  private destroyRef: DestroyRef = null!;
 
   public import(importation: Type<any> | ModuleWithProviders<any>): this
   public import(imports: (Type<any> | ModuleWithProviders<any>)[]): this
@@ -60,6 +58,5 @@ export class ComponentTestBedFactory<ComponentType> {
     await this.testBed.compileComponents();
 
     this.fixture = this.testBed.createComponent(this.rootComponent);
-    this.destroyRef = fromInjector(this.fixture, DestroyRef);
   }
 }

--- a/projects/ngx-testing-tools/src/lib/components/test-bed/component-test-bed.ts
+++ b/projects/ngx-testing-tools/src/lib/components/test-bed/component-test-bed.ts
@@ -1,4 +1,4 @@
-import { DestroyRef, Type } from '@angular/core';
+import { Type } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { assertComponentFixture } from './assert-fixture';
 import { buildComponentActionTools } from './component-action-tools';
@@ -19,7 +19,6 @@ export function componentTestBed<T>(rootComponent: Type<T>): ComponentTestBed<T>
       const fixture: ComponentFixture<T> = factory['fixture'];
       assertComponentFixture(fixture);
 
-      const destroyRef: DestroyRef = factory['destroyRef'];
       const { componentInstance: component, debugElement: debug } = fixture;
       const { injector } = debug;
 
@@ -28,7 +27,7 @@ export function componentTestBed<T>(rootComponent: Type<T>): ComponentTestBed<T>
 
       if (startDetectChanges) fixture.detectChanges();
 
-      return assertionCb({ fixture, component, injector, destroyRef, debug, query, action }, done);
+      return assertionCb({ fixture, component, injector, debug, query, action }, done);
     };
 
     return (assertionCb.length > 1)

--- a/projects/ngx-testing-tools/src/lib/components/test-bed/models/component-tools.model.ts
+++ b/projects/ngx-testing-tools/src/lib/components/test-bed/models/component-tools.model.ts
@@ -1,4 +1,4 @@
-import { DebugElement, DestroyRef, Injector } from '@angular/core';
+import { DebugElement, Injector } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { ComponentActionTools } from './component-action-tools.model';
 import { ComponentQueryTools } from './component-query-tools.model';
@@ -7,7 +7,6 @@ export interface ComponentTools<T> {
   fixture: ComponentFixture<T>;
   component: T;
   injector: Injector;
-  destroyRef: DestroyRef;
   debug: DebugElement;
   query: ComponentQueryTools;
   action: ComponentActionTools;


### PR DESCRIPTION
- Remove `DestroyRef` from `ComponentTools`.

Allows the lib to be compatible with Angular 15.2.
If the DestroyRef is required for tests, it should be injected directly.