### PR TITLE
Deprecate `debug` from `ComponentTools`

### DIFF
--- a/projects/ngx-testing-tools/src/lib/components/test-bed/models/component-tools.model.ts
+++ b/projects/ngx-testing-tools/src/lib/components/test-bed/models/component-tools.model.ts
@@ -7,6 +7,12 @@ export interface ComponentTools<T> {
   fixture: ComponentFixture<T>;
   component: T;
   injector: Injector;
+  /**
+   * Will be removed in v3.
+   *
+   * Use `fixture.debugElement` instead.
+   * @deprecated
+   */
   debug: DebugElement;
   query: ComponentQueryTools;
   action: ComponentActionTools;


### PR DESCRIPTION
Use `fixture.debugElement` instead.