### PR TITLE
Deprecate http, injector and module utilities outside custom test beds

### DIFF
--- a/projects/ngx-testing-tools/src/lib/http/controller.ts
+++ b/projects/ngx-testing-tools/src/lib/http/controller.ts
@@ -3,6 +3,7 @@ import { ErrorResponseConfig } from './models/error-response-config.model';
 import { ExpectRequestConfig } from './models/request-config.model';
 import { BodyType, SuccessResponseConfig } from './models/success-response-config.model';
 
+/** @deprecated Use `HttpTools` within custom test bed instead to access this utility. Will be removed in v3. */
 export function emitFakeSuccessResponse<T extends BodyType>(httpController: HttpTestingController, config: SuccessResponseConfig<T>): void {
   const { url, method, body, status, headers, statusText } = config;
 
@@ -11,6 +12,7 @@ export function emitFakeSuccessResponse<T extends BodyType>(httpController: Http
     .flush(body, { status, headers, statusText });
 }
 
+/** @deprecated Use `HttpTools` within custom test bed instead to access this utility. Will be removed in v3. */
 export function emitFakeErrorResponse(httpController: HttpTestingController, config: ErrorResponseConfig): void {
   const { url, method, status, statusText = 'Error' } = config;
   const error = new ProgressEvent(statusText);
@@ -20,6 +22,7 @@ export function emitFakeErrorResponse(httpController: HttpTestingController, con
     .error(error, { status, statusText });
 }
 
+/** @deprecated Use `HttpTools` within custom test bed instead to access this utility. Will be removed in v3. */
 export function expectHttpRequest(httpController: HttpTestingController, config: ExpectRequestConfig): TestRequest {
   const { url, method } = config;
 

--- a/projects/ngx-testing-tools/src/lib/http/models/request-config.model.ts
+++ b/projects/ngx-testing-tools/src/lib/http/models/request-config.model.ts
@@ -2,5 +2,5 @@ import { RequestMethod } from './request-method.model';
 
 export interface ExpectRequestConfig {
   url: string;
-  method: RequestMethod;
+  method?: RequestMethod;
 }

--- a/projects/ngx-testing-tools/src/lib/injector/from-injector.ts
+++ b/projects/ngx-testing-tools/src/lib/injector/from-injector.ts
@@ -1,6 +1,7 @@
 import { ProviderToken } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 
+/** @deprecated Use `ComponentTestBed` instead to access this utility. Will be removed in v3. */
 export function fromInjector<T>(fixture: ComponentFixture<any>, token: ProviderToken<T>): T {
   return fixture.debugElement.injector.get(token);
 }

--- a/projects/ngx-testing-tools/src/lib/module/export-module-to-create.ts
+++ b/projects/ngx-testing-tools/src/lib/module/export-module-to-create.ts
@@ -2,6 +2,7 @@ import { EnvironmentProviders, Provider, Type } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { shouldCreate } from '../common/expectation/should-create';
 
+/** @deprecated Use `ModuleTestBed` instead. Will be removed in v3. */
 export function expectModuleToCreate<T>(Module: Type<T>, providers: (Provider | EnvironmentProviders)[] = []): void {
   shouldCreate(() => TestBed
     .configureTestingModule({ imports: [Module], providers })


### PR DESCRIPTION
- Deprecate `emitFakeSuccessResponse`, `emitFakeErrorResponse` and `expectHttpRequest`.
- Deprecate `fromInjector`.
- Deprecate `expectModuleToCreate`.
