### PR TITLE
Deprecate pipe and interceptor external utilities

### DIFF
--- a/projects/ngx-testing-tools/src/lib/interceptor-test-bed/index.ts
+++ b/projects/ngx-testing-tools/src/lib/interceptor-test-bed/index.ts
@@ -1,6 +1,3 @@
 export * from './models';
 export { interceptorTestBed } from './interceptor-test-bed';
-export {
-  makeInterceptorSucceed,
-  makeInterceptorFail,
-} from './tools/interceptor';
+

--- a/projects/ngx-testing-tools/src/lib/v3-removed/index.ts
+++ b/projects/ngx-testing-tools/src/lib/v3-removed/index.ts
@@ -15,3 +15,5 @@ export { emitOutput } from '../component-test-bed/tools/action/utils/output';
 export { emitFakeSuccessResponse } from '../common/tools/http/utils/emit-success-response';
 export { emitFakeErrorResponse } from '../common/tools/http/utils/emit-error-response';
 export { expectHttpRequest } from './expect-http-response';
+
+export { makeInterceptorSucceed, makeInterceptorFail } from './interceptor';

--- a/projects/ngx-testing-tools/src/lib/v3-removed/interceptor.ts
+++ b/projects/ngx-testing-tools/src/lib/v3-removed/interceptor.ts
@@ -1,11 +1,12 @@
 import { HttpErrorResponse, HttpHandlerFn, HttpInterceptorFn, HttpRequest } from '@angular/common/http';
 import { Observable, of, throwError } from 'rxjs';
-import { ErrorInterceptorConfig, SuccessInterceptorConfig } from '../../common/tools/http/utils/models/interceptor-config.model';
+import { ErrorInterceptorConfig, SuccessInterceptorConfig } from '../common/tools/http/utils/models/interceptor-config.model';
 
 function mockSuccessHandlerFnFactory(): HttpHandlerFn {
   return (req: HttpRequest<unknown>) => of(req) as any;
 }
 
+/** @deprecated Use the `InterceptorTestBed` with `InspectTools` instead. Will be removed in v3. */
 export function makeInterceptorSucceed(interceptor: HttpInterceptorFn, config: SuccessInterceptorConfig = {}): Observable<HttpRequest<unknown>> {
   const { url = '/test', method = 'GET' } = config;
   const req = new HttpRequest<unknown>(method, url, null);
@@ -17,6 +18,7 @@ function mockErrorHandlerFnFactory(err: HttpErrorResponse): HttpHandlerFn {
   return () => throwError(() => err);
 }
 
+/** @deprecated Use the `InterceptorTestBed` with `InspectTools` instead. Will be removed in v3. */
 export function makeInterceptorFail(interceptor: HttpInterceptorFn, config: ErrorInterceptorConfig = {}): Observable<HttpRequest<unknown>> {
   const { url = '/test', status = 500 } = config;
   const req = new HttpRequest<unknown>('GET', url);

--- a/projects/ngx-testing-tools/src/lib/v3-removed/test-pipe-values.ts
+++ b/projects/ngx-testing-tools/src/lib/v3-removed/test-pipe-values.ts
@@ -1,5 +1,6 @@
 import { PipeTransform } from '@angular/core';
 
+/** @deprecated Use the `PipeTestBed` with `VerifyTools` instead. Will be removed in v3. */
 export function testPipeValues<T extends PipeTransform>(pipe: T, record: Record<any, string>): void {
   Object.entries(record).forEach(([current, expected]: [any, string]) => {
     it(`should transform "${current}" to "${expected}"`, () => {


### PR DESCRIPTION
- Deprecate `testPipeValues`.
- Deprecate `makeInterceptorSucceed` and `makeInterceptorFail`.